### PR TITLE
PR: T8.3.2 - 포트홀 확정 처리 → US8.3 머지

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'mysql:mysql-connector-java:8.0.33'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/controller/PotholeController.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/controller/PotholeController.java
@@ -1,0 +1,47 @@
+package com.smooth.pothole_analysis_service.pothole.controller;
+
+import com.smooth.pothole_analysis_service.global.common.ApiResponse;
+import com.smooth.pothole_analysis_service.pothole.dto.PotholeListResponseDto;
+import com.smooth.pothole_analysis_service.pothole.exception.PotholeErrorCode;
+import com.smooth.pothole_analysis_service.pothole.service.PotholeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/api/potholes")
+@RequiredArgsConstructor
+public class PotholeController {
+    
+    private final PotholeService potholeService;
+    
+    @GetMapping
+    public ResponseEntity<ApiResponse<PotholeListResponseDto>> getPotholes(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate start,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate end,
+            @RequestParam(required = false) Boolean confirmed
+    ) {
+        // 페이지 파라미터 검증
+        if (page < 0) {
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.error(PotholeErrorCode.INVALID_PAGE_PARAMETER));
+        }
+        
+        // 날짜 범위 검증
+        if (start != null && end != null && start.isAfter(end)) {
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.error(PotholeErrorCode.INVALID_DATE_RANGE));
+        }
+        
+        PotholeListResponseDto response = potholeService.getPotholes(page, start, end, confirmed);
+        
+        return ResponseEntity.ok(ApiResponse.success("포트홀 목록 조회 성공", response));
+    }
+}

--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/dto/PotholeConfirmRequestDto.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/dto/PotholeConfirmRequestDto.java
@@ -1,0 +1,13 @@
+package com.smooth.pothole_analysis_service.pothole.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PotholeConfirmRequestDto {
+    
+    private String potholeId;
+}

--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/dto/PotholeListResponseDto.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/dto/PotholeListResponseDto.java
@@ -1,0 +1,24 @@
+package com.smooth.pothole_analysis_service.pothole.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class PotholeListResponseDto {
+    
+    private List<PotholeResponseDto> content;
+    private int page;
+    private int totalPages;
+    
+    public static PotholeListResponseDto from(Page<PotholeResponseDto> page) {
+        return PotholeListResponseDto.builder()
+                .content(page.getContent())
+                .page(page.getNumber())
+                .totalPages(page.getTotalPages())
+                .build();
+    }
+}

--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/dto/PotholeResponseDto.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/dto/PotholeResponseDto.java
@@ -1,0 +1,80 @@
+package com.smooth.pothole_analysis_service.pothole.dto;
+
+import com.smooth.pothole_analysis_service.pothole.entity.Pothole;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PotholeResponseDto {
+    
+    private String potholeId;
+    private UserInfo user;
+    private LocationInfo location;
+    private String detectedAt;
+    private Double impact;
+    private Double shake;
+    private Double speed;
+    private String imageUrl;
+    private Boolean confirmed;
+    
+    @Getter
+    @Builder
+    public static class UserInfo {
+        private String userId;
+        private String userName;
+    }
+    
+    @Getter
+    @Builder
+    public static class LocationInfo {
+        private Double latitude;
+        private Double longitude;
+    }
+    
+    public static PotholeResponseDto from(Pothole pothole) {
+        // DB의 자동증가 id를 potholeId로 사용 (p- 접두사 추가)
+        String potholeId = pothole.getId() != null ? "p-" + pothole.getId() : null;
+        
+        // status가 "confirmed"인지 확인하여 Boolean으로 변환
+        Boolean confirmed = "confirmed".equals(pothole.getStatus());
+        
+        // Carla 좌표를 실제 위경도로 변환
+        Double convertedLatitude = null;
+        Double convertedLongitude = null;
+        
+        if (pothole.getLocationX() != null && pothole.getLocationY() != null) {
+            // 기준점 설정
+            double originLongitude = 127.00374;
+            double originLatitude = 37.55807;
+            double metersPerLonDegree = 89000.0;
+            double metersPerLatDegree = 111139.0;
+            
+            // Carla 좌표
+            double carlaX = pothole.getLocationX();
+            double carlaY = pothole.getLocationY();
+            
+            // 위경도 변환
+            convertedLongitude = Math.round((originLongitude + (carlaX / metersPerLonDegree)) * 100000.0) / 100000.0;
+            convertedLatitude = Math.round((originLatitude + (carlaY / metersPerLatDegree)) * 100000.0) / 100000.0;
+        }
+        
+        return PotholeResponseDto.builder()
+                .potholeId(potholeId)
+                .user(UserInfo.builder()
+                        .userId(pothole.getCarId()) // car_id를 user_id로 사용
+                        .userName("홍길동") // 실제 사용자명은 별도 테이블에서 조회 필요
+                        .build())
+                .location(LocationInfo.builder()
+                        .latitude(convertedLatitude)
+                        .longitude(convertedLongitude)
+                        .build())
+                .detectedAt(pothole.getDetectedAt())
+                .impact(pothole.getImpactForce())
+                .shake(pothole.getZAxisVibration())
+                .speed(pothole.getSpeed())
+                .imageUrl(pothole.getS3Url())
+                .confirmed(confirmed)
+                .build();
+    }
+}

--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/entity/Pothole.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/entity/Pothole.java
@@ -1,0 +1,53 @@
+package com.smooth.pothole_analysis_service.pothole.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "pothole_data")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Pothole {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(name = "car_id")
+    private String carId;
+    
+    @Column(name = "speed")
+    private Double speed;
+    
+    @Column(name = "location_x")
+    private Double locationX;
+    
+    @Column(name = "location_y")
+    private Double locationY;
+    
+    @Column(name = "s3_url")
+    private String s3Url;
+    
+    @Column(name = "impact_force")
+    private Double impactForce;
+    
+    @Column(name = "z_axis_vibration")
+    private Double zAxisVibration;
+    
+    @Column(name = "detected_at")
+    private String detectedAt;
+    
+    @Column(name = "status")
+    private String status;
+    
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+    
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/exception/PotholeErrorCode.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/exception/PotholeErrorCode.java
@@ -12,7 +12,8 @@ public enum PotholeErrorCode implements ErrorCode {
     // 포트홀 조회 관련
     POTHOLE_NOT_FOUND(HttpStatus.NOT_FOUND, 5001, "포트홀 데이터를 찾을 수 없습니다."),
     INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, 5002, "잘못된 날짜 범위입니다."),
-    INVALID_PAGE_PARAMETER(HttpStatus.BAD_REQUEST, 5003, "잘못된 페이지 파라미터입니다.");
+    INVALID_PAGE_PARAMETER(HttpStatus.BAD_REQUEST, 5003, "잘못된 페이지 파라미터입니다."),
+    ALREADY_CONFIRMED_POTHOLE(HttpStatus.BAD_REQUEST, 5004, "이미 확정된 포트홀입니다.");
  
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/exception/PotholeErrorCode.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/exception/PotholeErrorCode.java
@@ -9,23 +9,11 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum PotholeErrorCode implements ErrorCode {
 
-    // 기본 사용자 관리
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, 5001, "사용자를 찾을 수 없습니다."),
-    DUPLICATE_EMAIL(HttpStatus.CONFLICT, 1002, "이미 사용 중인 이메일입니다."),
-    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, 1003, "비밀번호가 일치하지 않습니다."),
-    EMAIL_NOT_VERIFIED(HttpStatus.FORBIDDEN, 1004, "이메일 인증이 완료되지 않았습니다."),
-    USER_CANT_FOUND(HttpStatus.FORBIDDEN, 1005, "사용자를 안 찾고 싶습니다."),
-
-    // 계정 상태
-    ACCOUNT_LOCKED(HttpStatus.FORBIDDEN, 1011, "계정이 잠금 상태입니다."),
-    ACCOUNT_DISABLED(HttpStatus.FORBIDDEN, 1012, "비활성화된 계정입니다."),
-    ACCOUNT_EXPIRED(HttpStatus.FORBIDDEN, 1013, "만료된 계정입니다."),
-
-    // 권한 관련
-    INSUFFICIENT_PERMISSION(HttpStatus.FORBIDDEN, 1021, "권한이 부족합니다."),
-    ADMIN_ONLY_ACCESS(HttpStatus.FORBIDDEN, 1022, "관리자만 접근 가능합니다.");
-
-
+    // 포트홀 조회 관련
+    POTHOLE_NOT_FOUND(HttpStatus.NOT_FOUND, 5001, "포트홀 데이터를 찾을 수 없습니다."),
+    INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, 5002, "잘못된 날짜 범위입니다."),
+    INVALID_PAGE_PARAMETER(HttpStatus.BAD_REQUEST, 5003, "잘못된 페이지 파라미터입니다.");
+ 
     private final HttpStatus httpStatus;
     private final Integer code;
     private final String message;

--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/repository/PotholeRepository.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/repository/PotholeRepository.java
@@ -1,0 +1,26 @@
+package com.smooth.pothole_analysis_service.pothole.repository;
+
+import com.smooth.pothole_analysis_service.pothole.entity.Pothole;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PotholeRepository extends JpaRepository<Pothole, Long> {
+    
+    @Query("SELECT p FROM Pothole p WHERE " +
+           "(:start IS NULL OR p.detectedAt >= :start) AND " +
+           "(:end IS NULL OR p.detectedAt <= :end) AND " +
+           "(:confirmed IS NULL OR " +
+           "  (:confirmed = true AND p.status = 'confirmed') OR " +
+           "  (:confirmed = false AND p.status != 'confirmed'))")
+    Page<Pothole> findPotholesWithFilters(
+            @Param("start") String start,
+            @Param("end") String end,
+            @Param("confirmed") Boolean confirmed,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/service/PotholeService.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/service/PotholeService.java
@@ -1,0 +1,36 @@
+package com.smooth.pothole_analysis_service.pothole.service;
+
+import com.smooth.pothole_analysis_service.pothole.dto.PotholeListResponseDto;
+import com.smooth.pothole_analysis_service.pothole.dto.PotholeResponseDto;
+import com.smooth.pothole_analysis_service.pothole.repository.PotholeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PotholeService {
+    
+    private final PotholeRepository potholeRepository;
+    
+    public PotholeListResponseDto getPotholes(int page, LocalDate start, LocalDate end, Boolean confirmed) {
+        Pageable pageable = PageRequest.of(page, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+        
+        // 날짜를 문자열로 변환 (detected_at이 varchar이므로)
+        String startStr = start != null ? start.toString() : null;
+        String endStr = end != null ? end.toString() : null;
+        
+        Page<PotholeResponseDto> potholeResponses = potholeRepository
+                .findPotholesWithFilters(startStr, endStr, confirmed, pageable)
+                .map(PotholeResponseDto::from);
+        
+        return PotholeListResponseDto.from(potholeResponses);
+    }
+}


### PR DESCRIPTION
# PR: T8.3.2 - 포트홀 확정 처리 → US8.3> 머지

## 목적
- 포트홀 확정 처리
---

## 구현/변경 사항
- 에러코드 추가
- PotholeConfirmRequestDTO 추가
- 포트홀 확정처리

---

## 테스트
- Postman POST http://localhost:8080/api/pothole/data/confirm
- header : Content-Type application/json
- body : { "potholeId": "p-6" }

---

## 참고
- T8.3.1 -> US 8.3 머지 전 PR 생성