### PR TITLE
PR: T8.3.1 - 테이블 데이터 조회 API 구현 → US8.3 머지

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.5'
+	id 'org.springframework.boot' version '3.3.4'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -28,17 +28,24 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-  implementation "software.amazon.awssdk:athena:2.20.112"
-  implementation 'software.amazon.awssdk:s3:2.21.29'
-  implementation "software.amazon.awssdk:sts:2.20.112"
-  implementation 'io.github.cdimascio:java-dotenv:5.2.2'
-  implementation 'mysql:mysql-connector-java:8.0.33'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation "software.amazon.awssdk:athena:2.20.112"
+    implementation 'software.amazon.awssdk:s3:2.21.29'
+    implementation "software.amazon.awssdk:sts:2.20.112"
+    implementation 'io.github.cdimascio:java-dotenv:5.2.2'
+    implementation 'mysql:mysql-connector-java:8.0.33'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:2023.0.4"
+	}
 }
 
 tasks.named('test') {

--- a/src/main/java/com/smooth/pothole_analysis_service/PotholeAnalysisServiceApplication.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/PotholeAnalysisServiceApplication.java
@@ -2,10 +2,12 @@ package com.smooth.pothole_analysis_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableFeignClients
 public class PotholeAnalysisServiceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/client/UserServiceClient.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/client/UserServiceClient.java
@@ -1,0 +1,13 @@
+package com.smooth.pothole_analysis_service.pothole.client;
+
+import com.smooth.pothole_analysis_service.pothole.dto.UserResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "user-service", url = "${user.service.url}")
+public interface UserServiceClient {
+    
+    @GetMapping("/api/users/{userId}")
+    UserResponseDto getUserById(@PathVariable("userId") String userId);
+}

--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/controller/DataProcessingController.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/controller/DataProcessingController.java
@@ -4,29 +4,33 @@ import com.smooth.pothole_analysis_service.global.common.ApiResponse;
 import com.smooth.pothole_analysis_service.global.exception.BusinessException;
 import com.smooth.pothole_analysis_service.pothole.dto.DataProcessingRequestDto;
 import com.smooth.pothole_analysis_service.pothole.dto.DataProcessingResponseDto;
+import com.smooth.pothole_analysis_service.pothole.dto.PotholeQueryResponseDto;
 import com.smooth.pothole_analysis_service.pothole.exception.PotholeErrorCode;
 import com.smooth.pothole_analysis_service.pothole.service.DataProcessingService;
+import com.smooth.pothole_analysis_service.pothole.service.PotholeQueryService;
 import com.smooth.pothole_analysis_service.pothole.service.ScheduledDataProcessingService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import java.time.LocalDate;
 
 // 포트홀 데이터 처리 컨트롤러 [S3 데이터 → Athena 쿼리 → RDS 저장 파이프라인]
+
 @Slf4j
 @RestController
-@RequestMapping("/api/pothole/athena")
+@RequestMapping("/api/pothole")
 @RequiredArgsConstructor
 public class DataProcessingController {
 
     private final DataProcessingService dataProcessingService;
     private final ScheduledDataProcessingService scheduledDataProcessingService;
+    private final PotholeQueryService potholeQueryService;
 
-    /**
-     * 핵심 기능: Athena 쿼리 실행 후 결과를 RDS에 저장
-     * POST /api/pothole/athena/result-save
-     */
-    @PostMapping("/result-save")
+    // Athena 쿼리 실행 후 결과를 RDS에 저장
+
+    @PostMapping("/athena/result-save")
     public ResponseEntity<ApiResponse<DataProcessingResponseDto>> queryAndSaveToRds(
             @RequestBody DataProcessingRequestDto requestDto) {
         try {
@@ -47,11 +51,9 @@ public class DataProcessingController {
         }
     }
 
-    /**
-     * 스케줄러를 수동으로 실행 (테스트용)
-     * POST /api/pothole/athena/run-scheduler
-     */
-    @PostMapping("/run-scheduler")
+    // 스케줄러를 수동으로 실행 (테스트용)
+
+    @PostMapping("/athena/run-scheduler")
     public ResponseEntity<ApiResponse<Void>> runSchedulerManually() {
         try {
             log.info("스케줄러 수동 실행 요청");
@@ -62,6 +64,31 @@ public class DataProcessingController {
         } catch (Exception e) {
             log.error("스케줄러 수동 실행 중 오류 발생", e);
             throw new BusinessException(PotholeErrorCode.SCHEDULER_EXECUTION_FAILED);
+        }
+    }
+
+    // 포트홀 데이터 조회 API
+    @GetMapping("/data")
+    public ResponseEntity<ApiResponse<PotholeQueryResponseDto>> getPotholeData(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate start,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate end,
+            @RequestParam(required = false) Boolean confirmed) {
+        
+        try {
+            // 기본값 설정
+            LocalDate defaultStart = start != null ? start : LocalDate.of(2025, 8, 1);
+            LocalDate defaultEnd = end != null ? end : LocalDate.of(2099, 12, 31);
+            
+            log.info("포트홀 데이터 조회 요청: page={}, start={}, end={}, confirmed={}", 
+                    page, defaultStart, defaultEnd, confirmed);
+            
+            PotholeQueryResponseDto data = potholeQueryService.getPotholeData(page, defaultStart, defaultEnd, confirmed);
+            return ResponseEntity.ok(ApiResponse.success("포트홀 목록 조회 성공", data));
+            
+        } catch (Exception e) {
+            log.error("포트홀 데이터 조회 중 오류 발생", e);
+            throw new BusinessException(PotholeErrorCode.DATA_PROCESSING_FAILED);
         }
     }
 }

--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/dto/PotholeQueryResponseDto.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/dto/PotholeQueryResponseDto.java
@@ -1,0 +1,53 @@
+package com.smooth.pothole_analysis_service.pothole.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PotholeQueryResponseDto {
+    
+    private List<PotholeContentDto> content;
+    private int page;
+    private int totalPages;
+    
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PotholeContentDto {
+        private String potholeId;
+        private UserDto user;
+        private LocationDto location;
+        private String detectedAt;
+        private Double impact;
+        private Double shake;
+        private Double speed;
+        private String imageUrl;
+        private boolean confirmed;
+    }
+    
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserDto {
+        private String userId;
+        private String userName;
+    }
+    
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class LocationDto {
+        private Double latitude;
+        private Double longitude;
+    }
+}

--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/dto/UserResponseDto.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/dto/UserResponseDto.java
@@ -1,0 +1,13 @@
+package com.smooth.pothole_analysis_service.pothole.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserResponseDto {
+    private String userId;
+    private String userName;
+}

--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/exception/PotholeErrorCode.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/exception/PotholeErrorCode.java
@@ -31,17 +31,17 @@ public enum PotholeErrorCode implements ErrorCode {
     DATA_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 5033, "데이터 처리 중 오류가 발생했습니다."),
     DUPLICATE_DATA_DETECTED(HttpStatus.CONFLICT, 5034, "중복된 데이터가 감지되었습니다."),
 
+    // AWS 서비스 관련
+    AWS_CREDENTIALS_INVALID(HttpStatus.UNAUTHORIZED, 5041, "AWS 인증 정보가 유효하지 않습니다."),
+    AWS_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, 5042, "AWS 서비스를 사용할 수 없습니다."),
+
     // 스케줄링 관련
     SCHEDULER_EXECUTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 5051, "스케줄러 실행에 실패했습니다."),
     SCHEDULER_ALREADY_RUNNING(HttpStatus.CONFLICT, 5052, "스케줄러가 이미 실행 중입니다."),
 
     // 요청 검증 관련
     INVALID_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST, 5061, "잘못된 요청 파라미터입니다."),
-    MISSING_REQUIRED_FIELD(HttpStatus.BAD_REQUEST, 5062, "필수 필드가 누락되었습니다."),
-
-    // AWS 서비스 관련
-    AWS_CREDENTIALS_INVALID(HttpStatus.UNAUTHORIZED, 5041, "AWS 인증 정보가 유효하지 않습니다."),
-    AWS_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, 5042, "AWS 서비스를 사용할 수 없습니다.");
+    MISSING_REQUIRED_FIELD(HttpStatus.BAD_REQUEST, 5062, "필수 필드가 누락되었습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/repository/PotholeDataRepository.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/repository/PotholeDataRepository.java
@@ -1,6 +1,8 @@
 package com.smooth.pothole_analysis_service.pothole.repository;
 
 import com.smooth.pothole_analysis_service.pothole.entity.PotholeData;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -21,4 +23,17 @@ public interface PotholeDataRepository extends JpaRepository<PotholeData, Long> 
                                 @Param("locationY") Double locationY,
                                 @Param("detectedAt") String detectedAt,
                                 @Param("impactForce") Double impactForce);
+    
+    // 날짜 범위로 포트홀 데이터 조회
+    @Query("SELECT p FROM PotholeData p WHERE p.detectedAt >= :startDate AND p.detectedAt <= :endDate ORDER BY p.detectedAt DESC")
+    Page<PotholeData> findByDetectedAtBetween(@Param("startDate") String startDate, 
+                                            @Param("endDate") String endDate, 
+                                            Pageable pageable);
+    
+    // 날짜 범위와 상태로 포트홀 데이터 조회
+    @Query("SELECT p FROM PotholeData p WHERE p.detectedAt >= :startDate AND p.detectedAt <= :endDate AND p.status = :status ORDER BY p.detectedAt DESC")
+    Page<PotholeData> findByDetectedAtBetweenAndStatus(@Param("startDate") String startDate, 
+                                                     @Param("endDate") String endDate, 
+                                                     @Param("status") String status, 
+                                                     Pageable pageable);
 }

--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/service/CoordinateConversionService.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/service/CoordinateConversionService.java
@@ -1,0 +1,37 @@
+package com.smooth.pothole_analysis_service.pothole.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class CoordinateConversionService {
+    
+    // 기준점(Origin)의 실제 경도, 위도
+    private static final double ORIGIN_LONGITUDE = 127.00374;
+    private static final double ORIGIN_LATITUDE = 37.55807;
+    
+    private static final double METERS_PER_LON_DEGREE = 89000.0;
+    private static final double METERS_PER_LAT_DEGREE = 111139.0;
+    
+    /**
+     * Carla 좌표계의 X, Y를 실제 위도, 경도로 변환
+     * @param carlaX Carla X 좌표
+     * @param carlaY Carla Y 좌표
+     * @return [경도, 위도] 배열
+     */
+    public double[] convertToLatLon(Double carlaX, Double carlaY) {
+        if (carlaX == null || carlaY == null) {
+            log.warn("좌표 변환 실패: carlaX={}, carlaY={}", carlaX, carlaY);
+            return new double[]{0.0, 0.0};
+        }
+        
+        double convertedLongitude = Math.round((ORIGIN_LONGITUDE + (carlaX / METERS_PER_LON_DEGREE)) * 100000.0) / 100000.0;
+        double convertedLatitude = Math.round((ORIGIN_LATITUDE + (carlaY / METERS_PER_LAT_DEGREE)) * 100000.0) / 100000.0;
+        
+        log.debug("좌표 변환: carlaX={}, carlaY={} -> longitude={}, latitude={}", 
+                 carlaX, carlaY, convertedLongitude, convertedLatitude);
+        
+        return new double[]{convertedLongitude, convertedLatitude};
+    }
+}

--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/service/PotholeQueryService.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/service/PotholeQueryService.java
@@ -1,0 +1,101 @@
+package com.smooth.pothole_analysis_service.pothole.service;
+
+import com.smooth.pothole_analysis_service.pothole.client.UserServiceClient;
+import com.smooth.pothole_analysis_service.pothole.dto.PotholeQueryResponseDto;
+import com.smooth.pothole_analysis_service.pothole.dto.UserResponseDto;
+import com.smooth.pothole_analysis_service.pothole.entity.PotholeData;
+import com.smooth.pothole_analysis_service.pothole.repository.PotholeDataRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PotholeQueryService {
+    
+    private final PotholeDataRepository potholeDataRepository;
+    private final UserServiceClient userServiceClient;
+    private final CoordinateConversionService coordinateConversionService;
+    
+    public PotholeQueryResponseDto getPotholeData(int page, LocalDate start, LocalDate end, Boolean confirmed) {
+        Pageable pageable = PageRequest.of(page, 10); // 페이지당 10개
+        
+        String startStr = start.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        String endStr = end.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        
+        Page<PotholeData> potholeDataPage;
+        
+        if (confirmed != null) {
+            // confirmed 상태에 따른 필터링 (예: "confirmed" 또는 "unconfirmed" 상태)
+            String status = confirmed ? "confirmed" : "unconfirmed";
+            potholeDataPage = potholeDataRepository.findByDetectedAtBetweenAndStatus(
+                startStr, endStr, status, pageable);
+        } else {
+            potholeDataPage = potholeDataRepository.findByDetectedAtBetween(
+                startStr, endStr, pageable);
+        }
+        
+        List<PotholeQueryResponseDto.PotholeContentDto> content = potholeDataPage.getContent()
+            .stream()
+            .map(this::convertToPotholeContentDto)
+            .collect(Collectors.toList());
+        
+        return PotholeQueryResponseDto.builder()
+            .content(content)
+            .page(page)
+            .totalPages(potholeDataPage.getTotalPages())
+            .build();
+    }
+    
+    private PotholeQueryResponseDto.PotholeContentDto convertToPotholeContentDto(PotholeData potholeData) {
+        // 좌표 변환
+        double[] latLon = coordinateConversionService.convertToLatLon(
+            potholeData.getLocationX(), potholeData.getLocationY());
+        
+        // 사용자 정보 조회
+        PotholeQueryResponseDto.UserDto userDto = getUserInfo(potholeData.getCarId());
+        
+        // 위치 정보 생성
+        PotholeQueryResponseDto.LocationDto locationDto = PotholeQueryResponseDto.LocationDto.builder()
+            .latitude(latLon[1])  // 위도
+            .longitude(latLon[0]) // 경도
+            .build();
+        
+        return PotholeQueryResponseDto.PotholeContentDto.builder()
+            .potholeId("p-" + potholeData.getId())
+            .user(userDto)
+            .location(locationDto)
+            .detectedAt(potholeData.getDetectedAt())
+            .impact(potholeData.getImpactForce())
+            .shake(potholeData.getZAxisVibration())
+            .speed(potholeData.getSpeed())
+            .imageUrl(potholeData.getS3Url())
+            .confirmed("confirmed".equals(potholeData.getStatus()))
+            .build();
+    }
+    
+    private PotholeQueryResponseDto.UserDto getUserInfo(String carId) {
+        try {
+            UserResponseDto userResponse = userServiceClient.getUserById(carId);
+            return PotholeQueryResponseDto.UserDto.builder()
+                .userId(userResponse.getUserId())
+                .userName(userResponse.getUserName())
+                .build();
+        } catch (Exception e) {
+            log.warn("사용자 정보 조회 실패: carId={}", carId, e);
+            return PotholeQueryResponseDto.UserDto.builder()
+                .userId(carId)
+                .userName("알 수 없음")
+                .build();
+        }
+    }
+}


### PR DESCRIPTION
# PR: T8.3.1 - 테이블 데이터 조회 API 구현 → US8.3 머지

## 목적
- 관리자 페이지 테이블 삽입 데이터 조회 API

---

## 구현/변경 사항
- OpenFeign 클라이언트 활용 유저 이름 조회
- 날짜, 확정여부 필터링 포트홀 데이터 조회
- x, y 좌표 위도 경도 변환 서비스

---

## 테스트 (있을 경우만 작성)
- Postman GET http://localhost:8080/api/pothole/data 를 통한 데이터 조회 성공
- page=2 / start=2025-08-01 / end=2025-08-31 / confirmed=true 의 추가 검색 필터 삽입 요청을 통한 데이터 조회 성공

---

## 참고
- US8.2 -> dev 머지에 따른 dev 변경사항 반영 후 코드 수정을 위한 재작업