### PR TITLE
PR: T8.3.2 - 포트홀 확정 처리 API 구현 → US8.3 머지

### DIFF
--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/client/UserServiceClient.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/client/UserServiceClient.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 
 @FeignClient(name = "user-service", url = "${user.service.url}")
 public interface UserServiceClient {
-    
-    @GetMapping("/api/users/{userId}")
-    UserResponseDto getUserById(@PathVariable("userId") String userId);
+
+    @GetMapping("/internal/v1/users/{userId}/admin-info")
+    UserResponseDto getUserById(@PathVariable("userId") Long userId);
 }

--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/controller/DataProcessingController.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/controller/DataProcessingController.java
@@ -5,9 +5,11 @@ import com.smooth.pothole_analysis_service.global.exception.BusinessException;
 import com.smooth.pothole_analysis_service.pothole.dto.DataProcessingRequestDto;
 import com.smooth.pothole_analysis_service.pothole.dto.DataProcessingResponseDto;
 import com.smooth.pothole_analysis_service.pothole.dto.PotholeQueryResponseDto;
+import com.smooth.pothole_analysis_service.pothole.dto.PotholeConfirmRequestDto;
 import com.smooth.pothole_analysis_service.pothole.exception.PotholeErrorCode;
 import com.smooth.pothole_analysis_service.pothole.service.DataProcessingService;
 import com.smooth.pothole_analysis_service.pothole.service.PotholeQueryService;
+import com.smooth.pothole_analysis_service.pothole.service.PotholeService;
 import com.smooth.pothole_analysis_service.pothole.service.ScheduledDataProcessingService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,7 +19,6 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 
 // 포트홀 데이터 처리 컨트롤러 [S3 데이터 → Athena 쿼리 → RDS 저장 파이프라인]
-
 @Slf4j
 @RestController
 @RequestMapping("/api/pothole")
@@ -27,9 +28,9 @@ public class DataProcessingController {
     private final DataProcessingService dataProcessingService;
     private final ScheduledDataProcessingService scheduledDataProcessingService;
     private final PotholeQueryService potholeQueryService;
+    private final PotholeService potholeService;
 
     // Athena 쿼리 실행 후 결과를 RDS에 저장
-
     @PostMapping("/athena/result-save")
     public ResponseEntity<ApiResponse<DataProcessingResponseDto>> queryAndSaveToRds(
             @RequestBody DataProcessingRequestDto requestDto) {
@@ -52,7 +53,6 @@ public class DataProcessingController {
     }
 
     // 스케줄러를 수동으로 실행 (테스트용)
-
     @PostMapping("/athena/run-scheduler")
     public ResponseEntity<ApiResponse<Void>> runSchedulerManually() {
         try {
@@ -90,5 +90,15 @@ public class DataProcessingController {
             log.error("포트홀 데이터 조회 중 오류 발생", e);
             throw new BusinessException(PotholeErrorCode.DATA_PROCESSING_FAILED);
         }
+    }
+
+    // 포트홀 확정 처리 API
+    @PostMapping("/data/confirm")
+    public ResponseEntity<ApiResponse<Void>> confirmPothole(@RequestBody PotholeConfirmRequestDto requestDto) {
+        log.info("포트홀 확정 처리 요청: potholeId={}", requestDto.getPotholeId());
+        
+        potholeService.confirmPothole(requestDto.getPotholeId());
+        
+        return ResponseEntity.ok(ApiResponse.success("포트홀 확정 처리가 완료되었습니다."));
     }
 }

--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/dto/PotholeConfirmRequestDto.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/dto/PotholeConfirmRequestDto.java
@@ -1,0 +1,12 @@
+package com.smooth.pothole_analysis_service.pothole.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PotholeConfirmRequestDto {
+    private String potholeId;
+}

--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/dto/UserResponseDto.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/dto/UserResponseDto.java
@@ -1,10 +1,14 @@
 package com.smooth.pothole_analysis_service.pothole.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @Data
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class UserResponseDto {

--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/exception/PotholeErrorCode.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/exception/PotholeErrorCode.java
@@ -41,7 +41,11 @@ public enum PotholeErrorCode implements ErrorCode {
 
     // 요청 검증 관련
     INVALID_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST, 5061, "잘못된 요청 파라미터입니다."),
-    MISSING_REQUIRED_FIELD(HttpStatus.BAD_REQUEST, 5062, "필수 필드가 누락되었습니다.");
+    MISSING_REQUIRED_FIELD(HttpStatus.BAD_REQUEST, 5062, "필수 필드가 누락되었습니다."),
+
+    // 포트홀 확정 관련
+    POTHOLE_NOT_FOUND(HttpStatus.NOT_FOUND, 5071, "포트홀 데이터를 찾을 수 없습니다."),
+    POTHOLE_ALREADY_CONFIRMED(HttpStatus.BAD_REQUEST, 5072, "이미 확정된 포트홀입니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/service/PotholeQueryService.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/service/PotholeQueryService.java
@@ -85,7 +85,7 @@ public class PotholeQueryService {
     
     private PotholeQueryResponseDto.UserDto getUserInfo(String carId) {
         try {
-            UserResponseDto userResponse = userServiceClient.getUserById(carId);
+            UserResponseDto userResponse = userServiceClient.getUserById(Long.valueOf(carId));
             return PotholeQueryResponseDto.UserDto.builder()
                 .userId(userResponse.getUserId())
                 .userName(userResponse.getUserName())


### PR DESCRIPTION
# PR: T8.3.2 - 포트홀 확정 처리 API 구현 → US8.3 머지

## 목적
- 관리자가 포트홀 이미지를 확인해서 포트홀을 확정 처리할 수 있다.

---

## 구현/변경 사항
- OpenFeign URL 수정
- 포트홀 확정 처리 API 구현

---

## 테스트 (있을 경우만 작성)
- Postman POST http://localhost:8080/api/pothole/data/confirm을 활용하여 성공 / 중복 / id오류 각각의 응답 성공
- POST 요청 바디 : { "potholeId": "p-23" } / { "potholeId": "p-1" }
