### PR TITLE
PR: T8.3.2 - 관리자 권한 확인 추가 → US8.3 머지

### DIFF
--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/controller/DataProcessingController.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/controller/DataProcessingController.java
@@ -1,5 +1,6 @@
 package com.smooth.pothole_analysis_service.pothole.controller;
 
+import com.smooth.pothole_analysis_service.global.auth.AuthenticationUtils;
 import com.smooth.pothole_analysis_service.global.common.ApiResponse;
 import com.smooth.pothole_analysis_service.global.exception.BusinessException;
 import com.smooth.pothole_analysis_service.pothole.dto.DataProcessingRequestDto;
@@ -96,6 +97,12 @@ public class DataProcessingController {
     @PostMapping("/data/confirm")
     public ResponseEntity<ApiResponse<Void>> confirmPothole(@RequestBody PotholeConfirmRequestDto requestDto) {
         log.info("포트홀 확정 처리 요청: potholeId={}", requestDto.getPotholeId());
+
+        if (!AuthenticationUtils.isAdmin()) {
+            log.warn("관리자가 아닌 사용자의 포트홀 확정 처리 시도: userId={}, role={}",
+                    AuthenticationUtils.getCurrentUserId(), AuthenticationUtils.getCurrentUserRole());
+            throw new BusinessException(PotholeErrorCode.ADMIN_PERMISSION_REQUIRED);
+        }
         
         potholeService.confirmPothole(requestDto.getPotholeId());
         

--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/exception/PotholeErrorCode.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/exception/PotholeErrorCode.java
@@ -45,7 +45,11 @@ public enum PotholeErrorCode implements ErrorCode {
 
     // 포트홀 확정 관련
     POTHOLE_NOT_FOUND(HttpStatus.NOT_FOUND, 5071, "포트홀 데이터를 찾을 수 없습니다."),
-    POTHOLE_ALREADY_CONFIRMED(HttpStatus.BAD_REQUEST, 5072, "이미 확정된 포트홀입니다.");
+    POTHOLE_ALREADY_CONFIRMED(HttpStatus.BAD_REQUEST, 5072, "이미 확정된 포트홀입니다."),
+
+    // 사용자 권한 관련
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 5081, "인증되지 않은 사용자입니다."),
+    ADMIN_PERMISSION_REQUIRED(HttpStatus.FORBIDDEN, 5082, "관리자 권한이 필요합니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;


### PR DESCRIPTION
# PR: T8.3.2 - 관리자 권한 확인 추가 → US8.3 머지

## 목적
- 포트홀 확정 처리는 관리자만 가능

---

## 구현/변경 사항
- 에러 코드 추가
- Util 파일 추가
- 관리자 권한 확인 코드 추가

---

## 테스트 (있을 경우만 작성)
- Postman Header에 
  { X-User-Id: 1, X-User-Role: ADMIN, X-User-Email: admin@example.com, X-Authenticated: true } 추가 전-후 처리 확인

---

## 참고
- 추후 US8.3 -> US11.2로 변경 예정