### PR TITLE
PR: T8.3.3 - 위-경도 변환 → US8.3 머지

### DIFF
--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/entity/PotholeData.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/entity/PotholeData.java
@@ -33,6 +33,12 @@ public class PotholeData {
     @Column(name = "location_y")
     private Double locationY;
 
+    @Column(name = "longitude")
+    private Double longitude;
+
+    @Column(name = "latitude")
+    private Double latitude;
+
     @Column(name = "s3_url")
     private String s3Url;
 

--- a/src/main/java/com/smooth/pothole_analysis_service/pothole/service/PotholeQueryService.java
+++ b/src/main/java/com/smooth/pothole_analysis_service/pothole/service/PotholeQueryService.java
@@ -24,7 +24,6 @@ public class PotholeQueryService {
     
     private final PotholeDataRepository potholeDataRepository;
     private final UserServiceClient userServiceClient;
-    private final CoordinateConversionService coordinateConversionService;
     
     public PotholeQueryResponseDto getPotholeData(int page, LocalDate start, LocalDate end, Boolean confirmed) {
         Pageable pageable = PageRequest.of(page, 10); // 페이지당 10개
@@ -57,17 +56,16 @@ public class PotholeQueryService {
     }
     
     private PotholeQueryResponseDto.PotholeContentDto convertToPotholeContentDto(PotholeData potholeData) {
-        // 좌표 변환
-        double[] latLon = coordinateConversionService.convertToLatLon(
-            potholeData.getLocationX(), potholeData.getLocationY());
-        
         // 사용자 정보 조회
         PotholeQueryResponseDto.UserDto userDto = getUserInfo(potholeData.getCarId());
         
+        Double latitude = potholeData.getLatitude();
+        Double longitude = potholeData.getLongitude();
+
         // 위치 정보 생성
         PotholeQueryResponseDto.LocationDto locationDto = PotholeQueryResponseDto.LocationDto.builder()
-            .latitude(latLon[1])  // 위도
-            .longitude(latLon[0]) // 경도
+            .latitude(latitude)
+            .longitude(longitude)
             .build();
         
         return PotholeQueryResponseDto.PotholeContentDto.builder()


### PR DESCRIPTION
# PR: T8.3.3 - 위-경도 변환 → US8.3 머지

## 목적
- 위도, 경도 변환 로직을 너무 많이 사용하게 되면 지연 발생 가능

---

## 구현/변경 사항
- 데이터 RDS 저장 시 위도, 경도 값으로 변환 구현
- 테이블용 데이터 조회 시 위도, 경도 값 변환 로직 삭제

---

## 테스트 (있을 경우만 작성)
- Postman 쿼리 결과 RDS 저장 API 호출 시 저장 데이터 확인

---

## 참고
- US8.3 -> US11.2 변환 예정